### PR TITLE
30459-missingcolumnfix

### DIFF
--- a/src/Dfe.Spi.IStoreAdapter.Application/Aggregator.cs
+++ b/src/Dfe.Spi.IStoreAdapter.Application/Aggregator.cs
@@ -125,6 +125,10 @@
             {
                 actualUnboxedFieldValue = dbDataReader[field];
             }
+            else
+            {
+                actualUnboxedFieldValue = DBNull.Value;
+            }
 
             IComparable actualUnboxedFieldValueComparable =
                 actualUnboxedFieldValue as IComparable;
@@ -195,22 +199,30 @@
                     break;
 
                 case DataOperator.GreaterThan:
-                    unboxedValue = this.UnboxFilterValue(field, value);
 
-                    compareToResult = actualUnboxedFieldValueComparable
-                        .CompareTo(unboxedValue);
+                    if (actualUnboxedFieldValueComparable != null)
+                    {
+                        unboxedValue = this.UnboxFilterValue(field, value);
 
-                    toReturn = compareToResult > 0;
+                        compareToResult = actualUnboxedFieldValueComparable
+                            .CompareTo(unboxedValue);
+
+                        toReturn = compareToResult > 0;
+                    }
 
                     break;
 
                 case DataOperator.GreaterThanOrEqualTo:
-                    unboxedValue = this.UnboxFilterValue(field, value);
 
-                    compareToResult = actualUnboxedFieldValueComparable
-                        .CompareTo(unboxedValue);
+                    if (actualUnboxedFieldValueComparable != null)
+                    {
+                        unboxedValue = this.UnboxFilterValue(field, value);
 
-                    toReturn = compareToResult >= 0;
+                        compareToResult = actualUnboxedFieldValueComparable
+                            .CompareTo(unboxedValue);
+
+                        toReturn = compareToResult >= 0;
+                    }
 
                     break;
 
@@ -223,21 +235,31 @@
                     break;
 
                 case DataOperator.LessThan:
-                    unboxedValue = this.UnboxFilterValue(field, value);
 
-                    compareToResult = actualUnboxedFieldValueComparable
-                        .CompareTo(unboxedValue);
+                    if (actualUnboxedFieldValueComparable != null)
+                    {
+                        unboxedValue = this.UnboxFilterValue(field, value);
 
-                    toReturn = compareToResult < 0;
+                        compareToResult = actualUnboxedFieldValueComparable
+                            .CompareTo(unboxedValue);
+
+                        toReturn = compareToResult < 0;
+                    }
+
                     break;
 
                 case DataOperator.LessThanOrEqualTo:
-                    unboxedValue = this.UnboxFilterValue(field, value);
 
-                    compareToResult = actualUnboxedFieldValueComparable
-                        .CompareTo(unboxedValue);
+                    if (actualUnboxedFieldValueComparable != null)
+                    {
+                        unboxedValue = this.UnboxFilterValue(field, value);
 
-                    toReturn = compareToResult <= 0;
+                        compareToResult = actualUnboxedFieldValueComparable
+                            .CompareTo(unboxedValue);
+
+                        toReturn = compareToResult <= 0;
+                    }
+
                     break;
 
                 default:

--- a/src/Dfe.Spi.IStoreAdapter.Application/CensusProcessor.cs
+++ b/src/Dfe.Spi.IStoreAdapter.Application/CensusProcessor.cs
@@ -194,6 +194,35 @@
             return toReturn;
         }
 
+        private static Dictionary<string, Type> ConvertMappingsResponseToFieldsAndTypes(
+            GetEnumerationMappingsResponse getEnumerationMappingsResponse)
+        {
+            Dictionary<string, Type> toReturn = null;
+
+            toReturn = getEnumerationMappingsResponse
+                .MappingsResult
+                .Mappings
+                .ToDictionary(
+                    x => x.Key,
+                    x =>
+                    {
+                        Type type = null;
+
+                        string typeStr = x.Value.FirstOrDefault();
+
+                        type = Type.GetType($"{nameof(System)}.{typeStr}");
+
+                        if (type == null)
+                        {
+                            throw new InvalidMappingTypeException(typeStr);
+                        }
+
+                        return type;
+                    });
+
+            return toReturn;
+        }
+
         private Census BuildCensusResults(
             Dictionary<string, AggregateQuery> aggregateQueries,
             DbDataReader dbDataReader)
@@ -255,35 +284,6 @@
             return toReturn;
         }
 
-        private Dictionary<string, Type> ConvertMappingsResponseToFieldsAndTypes(
-            GetEnumerationMappingsResponse getEnumerationMappingsResponse)
-        {
-            Dictionary<string, Type> toReturn = null;
-
-            toReturn = getEnumerationMappingsResponse
-                .MappingsResult
-                .Mappings
-                .ToDictionary(
-                    x => x.Key,
-                    x =>
-                    {
-                        Type type = null;
-
-                        string typeStr = x.Value.FirstOrDefault();
-
-                        type = Type.GetType($"{nameof(System)}.{typeStr}");
-
-                        if (type == null)
-                        {
-                            throw new InvalidMappingTypeException(typeStr);
-                        }
-
-                        return type;
-                    });
-
-            return toReturn;
-        }
-
         private async Task<Census> GetCensusAggregates(
             GetCensusRequest getCensusRequest,
             DatasetQueryFile datasetQueryFile,
@@ -310,7 +310,7 @@
                         .ConfigureAwait(false);
 
                 aggregationFieldsAndTypes =
-                    this.ConvertMappingsResponseToFieldsAndTypes(
+                    ConvertMappingsResponseToFieldsAndTypes(
                         getEnumerationMappingsResponse);
 
                 this.loggerWrapper.Info(


### PR DESCRIPTION
* Columns missing in a dataset need to be treated as if they're null and DBNull.Value is equal to this.
* Fixing null reference exception where actualUnboxedFieldValueComparable comes into play.